### PR TITLE
feat: vite-plugin-vue-style-bundler

### DIFF
--- a/public/plugins.json
+++ b/public/plugins.json
@@ -1718,5 +1718,23 @@
       "i18n"
      ],
     "type": "community"
+  },
+  {
+    "id": "vite-plugin-vue-style-bundler",
+    "name": "vite-plugin-vue-style-bundler",
+    "description": "automatically extract the css styles in Vue components and bundle them into the js source code",
+    "category": "Development Tools",
+    "packageName": "vite-plugin-vue-style-bundler",
+    "githubUrl": "https://github.com/zhangfisher/vite-plugin-vue-style-bundler",
+    "npmUrl": "https://www.npmjs.com/package/vite-plugin-vue-style-bundler",
+    "documentationUrl": "https://github.com/zhangfisher/vite-plugin-vue-style-bundler?tab=readme-ov-file",
+    "author": "zhangfisher",
+    "tags": [
+      "devtools",
+      "style",
+      "vite-plugin",
+      "development" 
+    ],
+    "type": "community"
   }
 ]


### PR DESCRIPTION
vite-plugin-vue-style-bundler can automatically extract the css styles in Vue components and bundle them into the js source code, and then automatically insert the style into the head at runtime. After being processed by vite-plugin-vue-style-bundler, you only need to import js when importing components.

## Description
Brief description of what this PR adds or changes.

## Type of Change
- [x] 🔌 Adding a new plugin
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation update
- [ ] 🔧 Other (please describe)

---

## Adding New Plugin Checklist
*Complete this section only if adding a new plugin*

### Required Steps ✅
- [x] Plugin added to `public/plugins.json`
- [ ] All required fields completed (`id`, `name`, `description`, `category`, `packageName`, `githubUrl`, `author`, `tags`, `type`)
- [ ] Plugin detail page tested and loads correctly
- [ ] Plugin information is accurate and up-to-date

### Plugin Details
- **Plugin Name**: `vite-plugin-vue-style-bundler`
- **Category**: `Development Tools`
- **Type**: community
- **GitHub URL**: `https://github.com/zhangfisher/vite-plugin-vue-style-bundler?tab=readme-ov-file`
vite-plugin-vue-style-bundler can automatically extract the css styles in Vue components and bundle them into the js source code, and then automatically insert the style into the head at runtime. After being processed by vite-plugin-vue-style-bundler, you only need to import js when importing components.
---

## General Checklist
- [x] Code follows the project's style guidelines
- [ ] Self-review completed
- [ ] Testing completed (if applicable)
- [ ] Documentation updated (if needed)
