### PR TITLE
feat: Extend author data structure for multiple entries with links

### DIFF
--- a/components/PluginDetailHeader.vue
+++ b/components/PluginDetailHeader.vue
@@ -27,7 +27,19 @@
           </span>
           <div class="flex items-center text-slate-600 dark:text-slate-300">
             <Icon name="lucide:user" class="h-4 w-4 mr-1" />
-            {{ plugin.author }}
+            <template v-for="(author, index) in authors" :key="typeof author === 'string' ? author : author.name">
+              <template v-if="typeof author === 'string'">
+                {{ author }}
+              </template>
+              <a
+                v-else
+                target="_blank"
+                class="text-[#4fc08d] hover:text-[#42b883] transition-colors"
+                :href="author.github_url"
+              >{{ author.name }}
+                <Icon name="lucide:external-link" class="h-4 w-4" /></a>
+              <span v-if="index < authors.length - 1" class="mr-1">, </span>
+            </template>
           </div>
           <div class="flex items-center text-slate-600 dark:text-slate-300">
             <Icon name="lucide:calendar" class="h-4 w-4 mr-1" />
@@ -50,13 +62,32 @@
 </template>
 
 <script setup lang="ts">
-import type { PluginWithStats } from '~/types'
+import type { Author, PluginWithStats } from '~/types'
 
 interface Props {
   plugin: PluginWithStats
 }
 
-defineProps<Props>()
+const props = defineProps<Props>()
+
+const {plugin} = toRefs(props)
+
+const authors = computed<Author[]>(() => {
+  // must be an array
+  const authorsArray = Array.isArray(plugin.value.author)
+    ? plugin.value.author
+    : [plugin.value.author]
+
+  // Guard: The `github_url` must have a GitHub URL Prefix. If not, handle the `name` as a string and ignore the URL.
+  const githubUrlRegex = /^https:\/\/(www\.)?github\.com\//
+  return authorsArray.map((author) => {
+    if (typeof author === 'string')
+      return author
+    if (author.github_url && githubUrlRegex.test(author.github_url))
+      return author
+    return author.name
+  })
+})
 
 const formatDate = (dateString: string) => {
   return new Date(dateString).toLocaleDateString('en-US', {

--- a/types/index.ts
+++ b/types/index.ts
@@ -19,9 +19,16 @@ export interface VuePlugin {
   githubUrl: string
   npmUrl?: string
   documentationUrl?: string
-  author: string
+  author: Author | Author[]
   tags: string[]
   type: "official" | "community"
+}
+
+export type Author = string | AuthorObj
+
+export interface AuthorObj {
+  name: string
+  github_url: string
 }
 
 export interface VuePluginWithStars extends VuePlugin {


### PR DESCRIPTION
## Description
Brief description of what this PR adds or changes.

## Type of Change
- [ ] 🔌 Adding a new plugin
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation update
- [ ] 🔧 Other (please describe)

---

This change extends the `author` property to support multiple authors and introduces a more complex object structure. The plugin view now correctly renders multiple authors, creating clickable links for those with a valid GitHub profile URL.

**Specifically, it addresses and includes the following:**
- The `author` data type is upgraded from a simple `string` to support `Author | Author[]`.
- `Author` is now a union type of `string | { name: string; github_url: string; }`.
- The plugin detail view is modified to iterate over and display a list of authors.
- A computed property is introduced to normalize the author data and validate the `github_url`.
- Author names with valid GitHub URLs are rendered as external links; all others appear as plain text.
